### PR TITLE
Port legacy UI sections into modal panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,27 +24,98 @@
         <div id="stats-panel" class="modal-panel">
             <button class="close-btn">X</button>
             <h2>🛡️ 플레이어 정보</h2>
+            <div>📊 레벨: <span id="level">1</span></div>
+            <div>📚 스킬포인트: <span id="skillPoints">0</span></div>
+            <div>✨ 스탯포인트: <span id="statPoints">0</span></div>
+            <div>💪 힘: <span id="strengthStat" onclick="allocateStat('strength')">5</span></div>
+            <div>🏃 민첩: <span id="agilityStat" onclick="allocateStat('agility')">5</span></div>
+            <div>🛡 체력: <span id="enduranceStat" onclick="allocateStat('endurance')">10</span></div>
+            <div>🔮 집중: <span id="focusStat" onclick="allocateStat('focus')">5</span></div>
+            <div>📖 지능: <span id="intelligenceStat" onclick="allocateStat('intelligence')">0</span></div>
+            <div>❤️ 체력: <span id="health">20</span>/<span id="maxHealth">20</span><span id="shield" class="shield-text"></span></div>
+            <div>🔋 마나: <span id="mana">10</span>/<span id="maxMana">10</span></div>
+            <div class="health-bar-container">
+                <div class="shield-bar" id="shield-bar"></div>
+                <div class="health-bar" id="hp-bar"></div>
             </div>
+            <div class="mana-bar-container">
+                <div class="mana-bar" id="mp-bar"></div>
+            </div>
+            <div>🍗 배부름: <span id="fullness">0</span></div>
+            <div>❤️‍🩹 회복력: <span id="healthRegen">0</span></div>
+            <div>🔁 마나회복: <span id="manaRegen">0.5</span></div>
+            <div>⚔️ 공격력: <span id="attackStat">5</span> <span id="weaponBonus"></span><span id="attackBuff" class="attack-buff-text"></span></div>
+            <div>🛡️ 방어력: <span id="defense">1</span> <span id="armorBonus"></span></div>
+            <div>🎯 명중률: <span id="accuracy">0.8</span></div>
+            <div>💨 회피율: <span id="evasion">0.1</span></div>
+            <div>💥 치명타: <span id="critChance">0.05</span></div>
+            <div>🔮 마법공격: <span id="magicPower">0</span></div>
+            <div>✨ 마법방어: <span id="magicResist">0</span></div>
+            <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
+            <div><img src="assets/images/gold.png" class="inline-icon"> 골드: <span id="gold">0</span></div>
+            <div>🏰 층: <span id="floor">1</span></div>
+        </div>
 
         <div id="inventory-panel" class="modal-panel wide">
             <button class="close-btn">X</button>
             <h2>🎒 인벤토리</h2>
+            <div class="equipped-items">
+                <h3>✨ 장착 중인 아이템</h3>
+                <div class="equipped-slot" id="equipped-weapon">무기: 없음</div>
+                <div class="equipped-slot" id="equipped-armor">방어구: 없음</div>
+                <div class="equipped-slot" id="equipped-accessory1">악세서리1: 없음</div>
+                <div class="equipped-slot" id="equipped-accessory2">악세서리2: 없음</div>
             </div>
+            <h3>📦 보유 아이템</h3>
+            <div id="inventory-filters" style="margin-bottom: 10px; display: flex; flex-wrap: wrap; gap: 5px;">
+                <button class="inv-filter-btn active" data-filter="all">모두</button>
+                <button class="inv-filter-btn" data-filter="equipment">장비</button>
+                <button class="inv-filter-btn" data-filter="recipe">레시피</button>
+                <button class="inv-filter-btn" data-filter="food">음식</button>
+                <button class="inv-filter-btn" data-filter="potion">포션</button>
+                <button class="inv-filter-btn" data-filter="map">지도</button>
+                <button class="inv-filter-btn" data-filter="etc">기타</button>
+            </div>
+            <div id="inventory-items"></div>
+        </div>
 
         <div id="mercenary-panel" class="modal-panel wide">
             <button class="close-btn">X</button>
             <h2>🤝 용병 부대</h2>
-            </div>
+            <div id="active-mercenary-list"></div>
+            <h3>💖 서포터</h3>
+            <div id="supporter-slots"></div>
+            <h3>대기 중</h3>
+            <div id="standby-mercenary-list"></div>
+            <h2>🥚 인큐베이터</h2>
+            <div id="incubator-slots"></div>
+            <h3>대기실</h3>
+            <div id="hatched-list"></div>
+            <h2>💼 용병 고용</h2>
+            <button class="hire-button" onclick="hireMercenary('WARRIOR')">⚔️ 전사 고용 (50💰)</button>
+            <button class="hire-button" onclick="hireMercenary('ARCHER')">🏹 궁수 고용 (60💰)</button>
+            <button class="hire-button" onclick="hireMercenary('HEALER')">✚ 힐러 고용 (70💰)</button>
+            <button class="hire-button" onclick="hireMercenary('WIZARD')">🔮 마법사 고용 (80💰)</button>
+            <button class="hire-button" onclick="hireMercenary('BARD')">🎶 음유시인 고용 (65💰)</button>
+        </div>
         
         <div id="skills-panel" class="modal-panel">
             <button class="close-btn">X</button>
             <h2>📚 스킬</h2>
-            </div>
+            <div id="skill-list"></div>
+            <div>1번 슬롯: <span id="skill1-name">없음</span></div>
+            <div>2번 슬롯: <span id="skill2-name">없음</span></div>
+        </div>
 
         <div id="materials-panel" class="modal-panel">
             <button class="close-btn">X</button>
             <h2>🛠️ 제작</h2>
-            </div>
+            <div id="materials-list"></div>
+            <h3>레시피</h3>
+            <div id="recipe-list"></div>
+            <h3>제작 중</h3>
+            <div id="crafting-queue"></div>
+        </div>
 
         <div id="game-options-panel" class="modal-panel">
             <button class="close-btn">X</button>


### PR DESCRIPTION
## Summary
- restore detailed UI blocks from the legacy HTML
- fill modal panels for player stats, inventory, mercenaries, skills, and crafting

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684db2bc8bc083279b59d5b992880510