### PR TITLE
Fix oversized icons with CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,5 +115,10 @@ body {
     line-height: 1;
 }
 
-/* 기존 패널 내부 스타일은 여기에 그대로 유지하거나 붙여넣습니다. */
-/* 예: .stats h2, .inventory-slot 등... */
+.inline-icon {
+    width: 24px;
+    height: 24px;
+    object-fit: contain;
+    vertical-align: middle;
+}
+


### PR DESCRIPTION
## Summary
- style `.inline-icon` elements so item icons don't show up huge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc073d9288327853936daf4c7e34e