### PR TITLE
Fix map size scaling

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -67,7 +67,10 @@ export const assetLoader = {
     }
 };
 
-const TILE_SIZE = 32; // 셀 하나의 크기
+// 게임 맵의 타일 크기. 값이 작을수록 화면에 표시되는 이미지가 작아집니다.
+// 패널 내 아이콘 크기를 조정한 뒤에도 맵 이미지가 너무 크게 보인다는
+// 피드백이 있어 기본 타일 크기를 줄입니다.
+const TILE_SIZE = 24;
 
 // 게임 상태를 캔버스에 그리는 메인 함수
 export function renderGame(canvas, ctx, images, gameState) {

--- a/main.js
+++ b/main.js
@@ -9,6 +9,13 @@ const { gameState, startGame, processTurn, movePlayer, useSkill, saveGame, loadG
 // --- UI 요소 가져오기 ---
 const canvas = document.getElementById('game-canvas');
 const ctx = canvas.getContext('2d');
+
+function resizeCanvas() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
 let gameImages = {};
 
 const modalOverlay = document.getElementById('modal-overlay');


### PR DESCRIPTION
## Summary
- shrink map images by reducing TILE_SIZE
- resize canvas to match viewport

## Testing
- `npm test` *(fails: Cannot find module runTests.js)*

------
https://chatgpt.com/codex/tasks/task_e_684dc3283d908327b8c81c3cba3a895d