### PR TITLE
Improve canvas scaling

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -70,7 +70,13 @@ export const assetLoader = {
 // 게임 맵의 타일 크기. 값이 작을수록 화면에 표시되는 이미지가 작아집니다.
 // 패널 내 아이콘 크기를 조정한 뒤에도 맵 이미지가 너무 크게 보인다는
 // 피드백이 있어 기본 타일 크기를 줄입니다.
-const TILE_SIZE = 24;
+export let TILE_SIZE = 32;
+
+export function updateTileSize(width, height) {
+    const base = Math.min(width, height);
+    const size = Math.round(base / 25);
+    TILE_SIZE = Math.min(48, Math.max(32, size));
+}
 
 // 게임 상태를 캔버스에 그리는 메인 함수
 export function renderGame(canvas, ctx, images, gameState) {

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 // main.js
 
-import { assetLoader, renderGame } from './canvasRenderer.js';
+import { assetLoader, renderGame, updateTileSize } from './canvasRenderer.js';
 import './src/mechanics.js';
 import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay } from './src/ui.js';
 
@@ -11,8 +11,15 @@ const canvas = document.getElementById('game-canvas');
 const ctx = canvas.getContext('2d');
 
 function resizeCanvas() {
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    const dpr = window.devicePixelRatio || 1;
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    updateTileSize(width, height);
 }
 window.addEventListener('resize', resizeCanvas);
 resizeCanvas();

--- a/style.css
+++ b/style.css
@@ -22,9 +22,12 @@ body {
 }
 
 #game-canvas {
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 #top-menu-bar {


### PR DESCRIPTION
## Summary
- tweak canvas scaling and high DPI rendering
- make tile size dynamic
- add crisp edges CSS style for game canvas

## Testing
- `npm test` *(fails: Cannot find module 'runTests.js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc4d0a578832799d251803b4d022d