### PR TITLE
Fix imports for browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,11 @@
 // main.js
 
 import { assetLoader, renderGame } from './canvasRenderer.js';
-import { gameState, startGame, processTurn, movePlayer, useSkill, saveGame, loadGame } from './src/mechanics.js';
 import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay } from './src/ui.js';
+
+// mechanics.js does not use ES module exports. It attaches its helpers to the
+// global `window` object, so we read them from there instead of importing.
+const { gameState, startGame, movePlayer, saveGame, loadGame } = window;
 
 // --- UI 요소 가져오기 ---
 const canvas = document.getElementById('game-canvas');

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,21 +1,29 @@
 // ui.js
-// This thin wrapper re-exports the UI helper functions that are defined in
-// mechanics.js.  mechanics.js attaches these helpers to the global `window`
-// object, so we expose them as ES module exports so that other modules can
-// import them normally.
+// This thin wrapper exposes the UI helper functions that are attached to the
+// global `window` object by `mechanics.js`.  The helpers are exported via both
+// CommonJS and a global assignment so that tests running in Node and the browser
+// code can access them without using ES module syntax.
 
-const {
-    updateStats,
-    updateInventoryDisplay,
-    updateMercenaryDisplay,
-    updateSkillDisplay,
-    updateMaterialsDisplay
-} = window;
+((global) => {
+    const {
+        updateStats,
+        updateInventoryDisplay,
+        updateMercenaryDisplay,
+        updateSkillDisplay,
+        updateMaterialsDisplay
+    } = global;
 
-export {
-    updateStats,
-    updateInventoryDisplay,
-    updateMercenaryDisplay,
-    updateSkillDisplay,
-    updateMaterialsDisplay
-};
+    const exportsObj = {
+        updateStats,
+        updateInventoryDisplay,
+        updateMercenaryDisplay,
+        updateSkillDisplay,
+        updateMaterialsDisplay
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = exportsObj;
+    } else {
+        Object.assign(global, exportsObj);
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- access mechanics helpers via window instead of failing ES module import
- expose UI helpers in a UMD wrapper so Node tests can load them

## Testing
- `npm test` *(fails: addMessage from mechanics.js can't read DOM element)*

------
https://chatgpt.com/codex/tasks/task_e_684dce2c4fe4832797d16758845a2027