### PR TITLE
Fix missing export usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,8 @@ import { assetLoader, renderGame } from './canvasRenderer.js';
 // 'ui.js' 파일이 src 폴더 안에 있다면 경로를 수정해주세요. 예: './src/ui.js'
 import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay } from './src/ui.js';
 // mechanics.js도 마찬가지로 src 폴더 안에 있다면 경로를 수정해주세요.
-import { gameState, startGame, processTurn, movePlayer, useSkill, saveGame, loadGame } from './src/mechanics.js';
+// mechanics.js에서 전역(window)으로 노출된 객체와 함수를 사용합니다.
+const { gameState, startGame, movePlayer, saveGame, loadGame } = window;
 
 // --- UI 요소 가져오기 ---
 const canvas = document.getElementById('game-canvas');


### PR DESCRIPTION
## Summary
- reference game functions from `window` instead of importing from `mechanics.js`

## Testing
- `npm test` *(fails: updateUnitEffectIcons is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684dd5a72a048327b02aa843c3898f80