### PR TITLE
Adjust tile scaling

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -68,9 +68,8 @@ export const assetLoader = {
 };
 
 // 게임 맵의 타일 크기. 값이 작을수록 화면에 표시되는 이미지가 작아집니다.
-// 패널 내 아이콘 크기를 조정한 뒤에도 맵 이미지가 너무 크게 보인다는
-// 피드백이 있어 기본 타일 크기를 줄입니다.
-export let TILE_SIZE = 32;
+// 이전에는 다소 작게 느껴진다는 의견이 있어 기본값을 약간 키웠습니다.
+export let TILE_SIZE = 36;
 
 export function updateTileSize(width, height) {
     const base = Math.min(width, height);

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 // main.js
 
-import { assetLoader, renderGame } from './canvasRenderer.js';
+import { assetLoader, renderGame, updateTileSize } from './canvasRenderer.js';
 // 'ui.js' 파일이 src 폴더 안에 있다면 경로를 수정해주세요. 예: './src/ui.js'
 import './src/ui.js';
 
@@ -25,6 +25,8 @@ function resizeCanvas() {
     // 캔버스의 실제 해상도를 현재 보이는 창의 크기와 일치시킵니다.
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
+    // 화면 크기에 맞춰 타일 크기도 조정합니다.
+    updateTileSize(canvas.width, canvas.height);
     
     // 리사이즈 후 즉시 다시 그려서 빈 화면이 보이지 않게 합니다.
     if (window.isGameReady) {


### PR DESCRIPTION
## Summary
- increase default TILE_SIZE for a slightly zoomed-in view
- auto-update tile size on canvas resize

## Testing
- `npm test` *(fails: purify did not remove status or mana cost incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684ddc6424e083278da5dd8d15092ee0