### PR TITLE
Improve canvas scaling for pixel-perfect rendering

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -84,8 +84,9 @@ export function renderGame(canvas, ctx, images, gameState) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.imageSmoothingEnabled = false;
 
-    const visibleWidth = Math.ceil(canvas.width / TILE_SIZE);
-    const visibleHeight = Math.ceil(canvas.height / TILE_SIZE);
+    const dpr = window.devicePixelRatio || 1;
+    const visibleWidth = Math.ceil(canvas.width / dpr / TILE_SIZE);
+    const visibleHeight = Math.ceil(canvas.height / dpr / TILE_SIZE);
 
     const startX = Math.floor(gameState.player.x - visibleWidth / 2);
     const startY = Math.floor(gameState.player.y - visibleHeight / 2);

--- a/main.js
+++ b/main.js
@@ -24,12 +24,23 @@ const closeButtons = document.querySelectorAll('.close-btn');
 
 // --- [추가] 캔버스 크기 조절 함수 ---
 function resizeCanvas() {
-    // 캔버스의 실제 해상도를 현재 보이는 창의 크기와 일치시킵니다.
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-    // 화면 크기에 맞춰 타일 크기도 조정합니다.
-    updateTileSize(canvas.width, canvas.height);
-    
+    const displayWidth = window.innerWidth;
+    const displayHeight = window.innerHeight;
+    const dpr = window.devicePixelRatio || 1;
+
+    // CSS 크기를 먼저 설정해 비율을 고정합니다.
+    canvas.style.width = displayWidth + 'px';
+    canvas.style.height = displayHeight + 'px';
+
+    // 해상도는 실제 픽셀 수에 맞춰 조정합니다.
+    canvas.width = Math.floor(displayWidth * dpr);
+    canvas.height = Math.floor(displayHeight * dpr);
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.imageSmoothingEnabled = false;
+
+    updateTileSize(displayWidth, displayHeight);
+
     // 리사이즈 후 즉시 다시 그려서 빈 화면이 보이지 않게 합니다.
     if (window.isGameReady) {
         renderGame(canvas, ctx, gameImages, gameState);

--- a/style.css
+++ b/style.css
@@ -22,9 +22,15 @@ body {
 }
 
 #game-canvas {
+    /* 픽셀 아트 선명도 유지 */
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+
+    /* 캔버스 스케일링 최적화 */
     width: 100%;
     height: 100%;
-    image-rendering: pixelated;
+    object-fit: contain;
 }
 
 /* === 2. 상단 메뉴 및 모달창 Z-index 설정 === */


### PR DESCRIPTION
## Summary
- tweak CSS for crisp canvas edges
- scale canvas resolution using device pixel ratio
- adjust visible area calculation

## Testing
- `npm test` *(fails: `graveChallenge.test.js` monsters not spawned)*

------
https://chatgpt.com/codex/tasks/task_e_684ddf1f2e148327a634298edc25e44e