### PR TITLE
Replace canvasRenderer content

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -1,217 +1,123 @@
 // canvasRenderer.js
 
+// [수정] 원하는 타일 크기로 설정합니다. 48, 64 등 자유롭게 조절해보세요.
+export const TILE_SIZE = 48;
+
 // 이미지 로딩을 위한 객체
 export const assetLoader = {
     images: {},
     imageSources: {
-        // Player & Mercenaries
         player: 'assets/images/player.png',
-        warrior: 'assets/images/warrior.png',
-        archer: 'assets/images/archer.png',
-        healer: 'assets/images/healer.png',
-        wizard: 'assets/images/wizard.png',
-        bard: 'assets/images/bard.png',
-        paladin: 'assets/images/paladin.png',
-
-        // Monsters
-        zombie: 'assets/images/zombie.png',
-        goblin: 'assets/images/goblin.png',
-        goblin_archer: 'assets/images/goblin-archer.png',
-        goblin_wizard: 'assets/images/goblin-wizard.png',
-        orc: 'assets/images/orc.png',
-        orc_archer: 'assets/images/orc_archer.png',
-        skeleton: 'assets/images/skeleton.png',
-        skeleton_mage: 'assets/images/skeleton_mage.png',
-        troll: 'assets/images/troll.png',
-        dark_mage: 'assets/images/dark_mage.png',
-        dark_knight: 'assets/images/dark_knight.png',
-        demon_warrior: 'assets/images/demon_warrior.png',
-        slime: 'assets/images/slime.png',
-        kobold: 'assets/images/kobold.png',
-        gargoyle: 'assets/images/gargoyle.png',
-        banshee: 'assets/images/banshee.png',
-        minotaur: 'assets/images/minotaur.png',
-        lich: 'assets/images/lich.png',
-        dragon_whelp: 'assets/images/dragon_whelp.png',
-        elemental_golem: 'assets/images/elemental_golem.png',
-        boss: 'assets/images/boss.png',
-
-        // Tiles & Objects
         floor: 'assets/images/floor-tile.png',
         wall: 'assets/images/wall-tile.png',
-        chest: 'assets/images/chest.png',
-        corpse: 'assets/images/corpse.png',
-        gold: 'assets/images/gold.png',
-
-        // Items
-        shortsword: 'assets/images/shortsword.png',
-        bow: 'assets/images/bow.png',
-        leatherarmor: 'assets/images/leatherarmor.png',
-
-        // Effects
-        dark_nova_effect: 'assets/images/dark-nova-effect.png'
+        zombie: 'assets/images/zombie.png',
+        warrior: 'assets/images/warrior.png',
+        archer: 'assets/images/archer.png',
+        wizard: 'assets/images/wizard.png',
+        healer: 'assets/images/healer.png',
+        bard: 'assets/images/bard.png',
+        paladin: 'assets/images/paladin.png',
+        // ... 필요한 모든 이미지 경로 추가 ...
     },
-
     load(callback) {
         let loaded = 0;
         const numImages = Object.keys(this.imageSources).length;
+        if (numImages === 0) {
+            callback({});
+            return;
+        }
         for (const key in this.imageSources) {
             this.images[key] = new Image();
             this.images[key].src = this.imageSources[key];
             this.images[key].onload = () => {
                 if (++loaded >= numImages) {
-                    callback(this.images); // 모든 이미지 로딩 완료 후 콜백 실행
+                    callback(this.images);
                 }
             };
+            this.images[key].onerror = () => {
+                console.error(`Failed to load image: ${this.imageSources[key]}`);
+                if (++loaded >= numImages) {
+                    callback(this.images);
+                }
+            }
         }
     }
 };
-
-// 게임 맵의 타일 크기. 값이 작을수록 화면에 표시되는 이미지가 작아집니다.
-// 이전에는 다소 작게 느껴진다는 의견이 있어 기본값을 약간 키웠습니다.
-export let TILE_SIZE = 48;
-
-export function updateTileSize(width, height) {
-    const base = Math.min(width, height);
-    const size = Math.round(base / 25);
-    TILE_SIZE = Math.min(48, Math.max(32, size));
-}
 
 // 게임 상태를 캔버스에 그리는 메인 함수
 export function renderGame(canvas, ctx, images, gameState) {
     if (!canvas || !ctx) return;
-
+    
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.imageSmoothingEnabled = false;
 
-    const dpr = window.devicePixelRatio || 1;
-    const visibleWidth = Math.ceil(canvas.width / dpr / TILE_SIZE);
-    const visibleHeight = Math.ceil(canvas.height / dpr / TILE_SIZE);
+    const cameraX = Math.floor(gameState.player.x - (canvas.width / TILE_SIZE / 2));
+    const cameraY = Math.floor(gameState.player.y - (canvas.height / TILE_SIZE / 2));
 
-    const startX = Math.floor(gameState.player.x - visibleWidth / 2);
-    const startY = Math.floor(gameState.player.y - visibleHeight / 2);
+    const startCol = Math.max(0, cameraX);
+    const endCol = Math.min(gameState.dungeonSize, cameraX + Math.ceil(canvas.width / TILE_SIZE) + 1);
+    const startRow = Math.max(0, cameraY);
+    const endRow = Math.min(gameState.dungeonSize, cameraY + Math.ceil(canvas.height / TILE_SIZE) + 1);
 
-    for (let y = 0; y < visibleHeight; y++) {
-        for (let x = 0; x < visibleWidth; x++) {
-            const mapX = startX + x;
-            const mapY = startY + y;
-            const screenX = x * TILE_SIZE;
-            const screenY = y * TILE_SIZE;
-            if (mapX < 0 || mapY < 0 || mapX >= gameState.dungeonSize || mapY >= gameState.dungeonSize) continue;
+    // 타일, 지형지물, 아이템 그리기
+    for (let y = startRow; y < endRow; y++) {
+        for (let x = startCol; x < endCol; x++) {
+            const screenX = (x - cameraX) * TILE_SIZE;
+            const screenY = (y - cameraY) * TILE_SIZE;
 
-            const cellType = gameState.dungeon[mapY][mapX];
-            const tileImage = (cellType === 'wall') ? images.wall : images.floor;
-            if (tileImage) ctx.drawImage(tileImage, screenX, screenY, TILE_SIZE, TILE_SIZE);
-            if (images[cellType]) ctx.drawImage(images[cellType], screenX, screenY, TILE_SIZE, TILE_SIZE);
-
-            const item = gameState.items.find(it => it.x === mapX && it.y === mapY);
-            if (item && images[item.key]) ctx.drawImage(images[item.key], screenX, screenY, TILE_SIZE, TILE_SIZE);
-
-            const corpse = gameState.corpses && gameState.corpses.find(c => c.x === mapX && c.y === mapY);
-            if (corpse && images.corpse) ctx.drawImage(images.corpse, screenX, screenY, TILE_SIZE, TILE_SIZE);
-        }
-    }
-
-    const allUnits = [...gameState.monsters, ...gameState.activeMercenaries, gameState.player]
-        .filter(u => u && (u.health === undefined || u.health > 0))
-        .sort((a, b) => a.y - b.y);
-    allUnits.forEach(unit => {
-        const screenX = (unit.x - startX) * TILE_SIZE;
-        const screenY = (unit.y - startY) * TILE_SIZE;
-        if (screenX < -TILE_SIZE || screenX > canvas.width || screenY < -TILE_SIZE || screenY > canvas.height) return;
-        const key = unit.type ? unit.type.toLowerCase() : (unit.id === 'player' ? 'player' : 'zombie');
-        const img = images[key] || images.zombie;
-        if (img) ctx.drawImage(img, screenX, screenY, TILE_SIZE, TILE_SIZE);
-        drawHealthBar(ctx, screenX, screenY, TILE_SIZE, unit);
-        drawEffectIcons(ctx, screenX, screenY, TILE_SIZE, unit);
-    });
-
-    if (Array.isArray(gameState.projectiles)) {
-        ctx.font = '16px sans-serif';
-        gameState.projectiles.forEach(p => {
-            const sx = (p.x - startX) * TILE_SIZE;
-            const sy = (p.y - startY) * TILE_SIZE;
-            if (sx < -TILE_SIZE || sx > canvas.width || sy < -TILE_SIZE || sy > canvas.height) return;
-            ctx.fillText(p.icon || '⬤', sx + TILE_SIZE / 4, sy + TILE_SIZE / 2);
-        });
-    }
-
-    for (let y = 0; y < visibleHeight; y++) {
-        for (let x = 0; x < visibleWidth; x++) {
-            const mapX = startX + x;
-            const mapY = startY + y;
-            if (mapX < 0 || mapY < 0 || mapX >= gameState.dungeonSize || mapY >= gameState.dungeonSize) continue;
-            if (gameState.fogOfWar[mapY]?.[mapX]) {
+            if (gameState.fogOfWar[y]?.[x]) {
                 ctx.fillStyle = '#000';
-                ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+                ctx.fillRect(screenX, screenY, TILE_SIZE, TILE_SIZE);
+                continue;
+            }
+
+            const cellType = gameState.dungeon[y][x];
+            const tileImage = (cellType === 'wall') ? images.wall : images.floor;
+            if(tileImage) ctx.drawImage(tileImage, screenX, screenY, TILE_SIZE, TILE_SIZE); // [수정]
+
+            if (images[cellType]) {
+                ctx.drawImage(images[cellType], screenX, screenY, TILE_SIZE, TILE_SIZE); // [수정]
             }
         }
     }
+
+    // 유닛(몬스터, 용병, 플레이어)과 UI 그리기
+    const allUnits = [...gameState.monsters, ...gameState.activeMercenaries, gameState.player].sort((a, b) => a.y - b.y);
+    allUnits.forEach(unit => {
+        if(!unit || (unit.health !== undefined && unit.health <= 0)) return;
+
+        const screenX = (unit.x - cameraX) * TILE_SIZE;
+        const screenY = (unit.y - cameraY) * TILE_SIZE;
+
+        if (screenX < -TILE_SIZE || screenX > canvas.width || screenY < -TILE_SIZE || screenY > canvas.height) return;
+
+        const unitImageKey = unit.type ? unit.type.toLowerCase() : (unit.id === 'player' ? 'player' : 'zombie');
+        const unitImage = images[unitImageKey] || images.zombie;
+        
+        if (unitImage) ctx.drawImage(unitImage, screenX, screenY, TILE_SIZE, TILE_SIZE); // [수정]
+
+        drawHealthBar(ctx, screenX, screenY, TILE_SIZE, unit); // [수정]
+        drawEffectIcons(ctx, screenX, screenY, TILE_SIZE, unit); // [수정]
+    });
 }
 
-function drawHealthBar(ctx, x, y, size, unit) {
+function drawHealthBar(ctx, x, y, size, unit) { // [수정] size 매개변수 추가
     const maxHp = getStat(unit, 'maxHealth');
-    if (maxHp && unit.health < maxHp) {
-        const ratio = unit.health / maxHp;
+    if (maxHp > 0 && unit.health < maxHp) {
+        const hpRatio = unit.health / maxHp;
         ctx.fillStyle = '#333';
-        ctx.fillRect(x, y - 6, size, 4);
-        ctx.fillStyle = ratio > 0.5 ? '#0f0' : ratio > 0.25 ? '#ff0' : '#f00';
-        ctx.fillRect(x, y - 6, size * ratio, 4);
+        ctx.fillRect(x, y - 8, size, 5); // [수정]
+        ctx.fillStyle = hpRatio > 0.5 ? '#4CAF50' : hpRatio > 0.25 ? '#FFC107' : '#F44336';
+        ctx.fillRect(x, y - 8, size * hpRatio, 5); // [수정]
     }
 }
 
-function drawEffectIcons(ctx, x, y, size, unit) {
-    ctx.font = '10px sans-serif';
-    ctx.fillStyle = 'white';
-    const buffIcons = getActiveBuffIcons(unit);
-    const debuffIcons = getActiveDebuffIcons(unit);
-    buffIcons.forEach((icon, idx) => {
-        ctx.fillText(icon, x + idx * 12, y - 5);
-    });
-    debuffIcons.forEach((icon, idx) => {
-        ctx.fillText(icon, x + idx * 12, y + size + 10);
-    });
+function drawEffectIcons(ctx, x, y, size, unit) { // [수정] size 매개변수 추가
+    // 이 함수는 나중에 버프/디버프 아이콘을 그릴 때 사용됩니다.
+    // 현재는 비워두어도 괜찮습니다.
 }
 
-const STATUS_ICONS = {
-    poison: '☠️',
-    burn: '🔥',
-    freeze: '❄️',
-    bleed: '🩸',
-    paralysis: '⚡',
-    nightmare: '😱',
-    silence: '🤐',
-    petrify: '🪨',
-    debuff: '⬇️'
-};
-
-function getActiveBuffIcons(unit) {
-    const icons = [];
-    if (Array.isArray(unit.buffs)) {
-        unit.buffs.forEach(b => {
-            const defs = window.SKILL_DEFS || {};
-            const info = defs[b.name] || (window.MERCENARY_SKILLS && window.MERCENARY_SKILLS[b.name]) || (window.MONSTER_SKILLS && window.MONSTER_SKILLS[b.name]);
-            if (info && info.icon) icons.push(info.icon);
-        });
-    }
-    if (unit.shield && unit.shieldTurns > 0) icons.push('🛡️');
-    if (unit.attackBuff && unit.attackBuffTurns > 0) icons.push('💪');
-    return icons;
-}
-
-function getActiveDebuffIcons(unit) {
-    const icons = [];
-    for (const key in STATUS_ICONS) {
-        if (unit[key]) icons.push(STATUS_ICONS[key]);
-    }
-    return icons;
-}
-
-// 이 파일에서 사용될 getStat 함수 (mechanics.js에도 동일 함수가 있음)
-// 모듈 시스템에서는 각 파일이 독립적이므로, 필요 함수를 가져오거나 직접 정의해야 합니다.
-// 여기서는 간단하게 gameState에서 직접 가져오는 것으로 대체합니다.
+// 이 파일에서만 임시로 사용하는 getStat 함수
 function getStat(unit, stat) {
-    // mechanics.js의 getStat 함수 로직이 여기에 필요합니다.
-    // 지금은 임시로 기본값만 반환합니다.
     return unit[stat] || 0;
 }


### PR DESCRIPTION
## Summary
- replace `canvasRenderer.js` with updated rendering logic that uses a fixed tile size and simplified draw routines

## Testing
- `npm test` *(fails: heal on kill not applied)*

------
https://chatgpt.com/codex/tasks/task_e_684e2db5520c8327bfd785646f531344