### PR TITLE
Clamp camera to map bounds

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -58,8 +58,13 @@ export function renderGame(canvas, ctx, images, gameState) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.imageSmoothingEnabled = false;
 
-    const cameraX = Math.floor(gameState.player.x - (canvas.width / TILE_SIZE / 2));
-    const cameraY = Math.floor(gameState.player.y - (canvas.height / TILE_SIZE / 2));
+    const halfScreenTilesX = canvas.width / TILE_SIZE / 2;
+    const halfScreenTilesY = canvas.height / TILE_SIZE / 2;
+    let cameraX = Math.floor(gameState.player.x - halfScreenTilesX);
+    let cameraY = Math.floor(gameState.player.y - halfScreenTilesY);
+
+    cameraX = Math.max(0, Math.min(cameraX, gameState.dungeonSize - canvas.width / TILE_SIZE));
+    cameraY = Math.max(0, Math.min(cameraY, gameState.dungeonSize - canvas.height / TILE_SIZE));
 
     const startCol = Math.max(0, cameraX);
     const endCol = Math.min(gameState.dungeonSize, cameraX + Math.ceil(canvas.width / TILE_SIZE) + 1);

--- a/index.html
+++ b/index.html
@@ -139,7 +139,6 @@
     <script type="module" src="./src/mechanics.js"></script>
     <script type="module" src="./src/ui.js"></script>
     <script type="module" src="./canvasRenderer.js"></script>
-    <script type="module" src="main.js"></script>
     <script type="module" src="./main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep the camera within the dungeon limits so the map stays visible

## Testing
- `npm test --silent` *(fails: graveChallenge.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684e33e323308327a5cb02646a6d585a