### PR TITLE
Fix log visibility and draw items on map

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -24,6 +24,9 @@ export const assetLoader = {
         healer: 'assets/images/healer.png',
         bard: 'assets/images/bard.png',
         paladin: 'assets/images/paladin.png',
+        item: 'assets/images/gold.png',
+        corpse: 'assets/images/corpse.png',
+        chest: 'assets/images/chest.png',
         // ... 필요한 모든 이미지 경로 추가 ...
     },
     load(callback) {
@@ -88,10 +91,25 @@ export function renderGame(canvas, ctx, images, gameState) {
 
             const cellType = gameState.dungeon[y][x];
             const tileImage = (cellType === 'wall') ? images.wall : images.floor;
-            if(tileImage) ctx.drawImage(tileImage, screenX, screenY, TILE_SIZE, TILE_SIZE); // [수정]
+            if(tileImage) ctx.drawImage(tileImage, screenX, screenY, TILE_SIZE, TILE_SIZE);
 
             if (images[cellType]) {
-                ctx.drawImage(images[cellType], screenX, screenY, TILE_SIZE, TILE_SIZE); // [수정]
+                ctx.drawImage(images[cellType], screenX, screenY, TILE_SIZE, TILE_SIZE);
+            } else {
+                const colors = {
+                    chest: '#B8860B',
+                    mine: '#888',
+                    tree: '#228B22',
+                    bones: '#DDD',
+                    grave: '#555',
+                    altar: '#FFCC00',
+                    exit: '#00FFFF',
+                    shop: '#FF69B4'
+                };
+                if (colors[cellType]) {
+                    ctx.fillStyle = colors[cellType];
+                    ctx.fillRect(screenX, screenY, TILE_SIZE, TILE_SIZE);
+                }
             }
         }
     }

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 
     <div id="game-over-panel" style="display:none;"></div>
     <div id="item-detail-panel" class="details-panel" style="display:none;"></div>
-    <div id="message-log" style="display:none;"></div>
+    <div id="message-log"></div>
 
     <script src="dice.js"></script>
     <script type="module" src="./src/state.js"></script>

--- a/style.css
+++ b/style.css
@@ -70,6 +70,20 @@ body {
     align-items: center;
 }
 
+#message-log {
+    position: fixed;
+    left: 10px;
+    bottom: 10px;
+    width: 300px;
+    max-height: 40vh;
+    overflow-y: auto;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #eee;
+    font-size: 14px;
+    padding: 5px;
+    z-index: 150;
+}
+
 #modal-overlay.hidden {
     display: none;
 }


### PR DESCRIPTION
## Summary
- load graphics for items, corpses and chests
- draw map objects like corpses, items and chests
- show the message log by default
- style the message log so it appears in the corner

## Testing
- `npm test` *(fails: purify did not remove status or mana cost incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684e3a9a1ce48327a88d7816f33109ab