### PR TITLE
Implement fixed layout with side stats panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,51 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="game-container">
-        <canvas id="game-canvas"></canvas>
+    <div id="layout">
+        <div id="top-area">
+            <div id="game-container">
+                <canvas id="game-canvas"></canvas>
+            </div>
+            <div id="stats-panel" class="side-panel">
+                <h2>🛡️ 플레이어 정보</h2>
+                <div>📊 레벨: <span id="level">1</span></div>
+                <div>📚 스킬포인트: <span id="skillPoints">0</span></div>
+                <div>✨ 스탯포인트: <span id="statPoints">0</span></div>
+                <div>💪 힘: <span id="strengthStat" onclick="allocateStat('strength')">5</span></div>
+                <div>🏃 민첩: <span id="agilityStat" onclick="allocateStat('agility')">5</span></div>
+                <div>🛡 체력: <span id="enduranceStat" onclick="allocateStat('endurance')">10</span></div>
+                <div>🔮 집중: <span id="focusStat" onclick="allocateStat('focus')">5</span></div>
+                <div>📖 지능: <span id="intelligenceStat" onclick="allocateStat('intelligence')">0</span></div>
+                <div>❤️ 체력: <span id="health">20</span>/<span id="maxHealth">20</span><span id="shield" class="shield-text"></span></div>
+                <div>🔋 마나: <span id="mana">10</span>/<span id="maxMana">10</span></div>
+                <div class="health-bar-container">
+                    <div class="shield-bar" id="shield-bar"></div>
+                    <div class="health-bar" id="hp-bar"></div>
+                </div>
+                <div class="mana-bar-container">
+                    <div class="mana-bar" id="mp-bar"></div>
+                </div>
+                <div>🍗 배부름: <span id="fullness">0</span></div>
+                <div>❤️‍🩹 회복력: <span id="healthRegen">0</span></div>
+                <div>🔁 마나회복: <span id="manaRegen">0.5</span></div>
+                <div>⚔️ 공격력: <span id="attackStat">5</span> <span id="weaponBonus"></span><span id="attackBuff" class="attack-buff-text"></span></div>
+                <div>🛡️ 방어력: <span id="defense">1</span> <span id="armorBonus"></span></div>
+                <div>🎯 명중률: <span id="accuracy">0.8</span></div>
+                <div>💨 회피율: <span id="evasion">0.1</span></div>
+                <div>💥 치명타: <span id="critChance">0.05</span></div>
+                <div>🔮 마법공격: <span id="magicPower">0</span></div>
+                <div>✨ 마법방어: <span id="magicResist">0</span></div>
+                <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
+                <div><img src="assets/images/gold.png" class="inline-icon"> 골드: <span id="gold">0</span></div>
+                <div>🏰 층: <span id="floor">1</span></div>
+                <div id="equipped-tile-side">타일: 없음</div>
+                <div id="turn-effects"></div>
+            </div>
+        </div>
+        <div id="message-log"></div>
     </div>
 
     <div id="top-menu-bar">
-        <button class="menu-btn" data-panel-id="stats-panel">내 정보</button>
         <button class="menu-btn" data-panel-id="inventory-panel">인벤토리</button>
         <button class="menu-btn" data-panel-id="mercenary-panel">용병 부대</button>
         <button class="menu-btn" data-panel-id="skills-panel">스킬</button>
@@ -20,43 +59,6 @@
     </div>
 
     <div id="modal-overlay" class="hidden">
-        
-        <div id="stats-panel" class="modal-panel">
-            <button class="close-btn">X</button>
-            <h2>🛡️ 플레이어 정보</h2>
-            <div>📊 레벨: <span id="level">1</span></div>
-            <div>📚 스킬포인트: <span id="skillPoints">0</span></div>
-            <div>✨ 스탯포인트: <span id="statPoints">0</span></div>
-            <div>💪 힘: <span id="strengthStat" onclick="allocateStat('strength')">5</span></div>
-            <div>🏃 민첩: <span id="agilityStat" onclick="allocateStat('agility')">5</span></div>
-            <div>🛡 체력: <span id="enduranceStat" onclick="allocateStat('endurance')">10</span></div>
-            <div>🔮 집중: <span id="focusStat" onclick="allocateStat('focus')">5</span></div>
-            <div>📖 지능: <span id="intelligenceStat" onclick="allocateStat('intelligence')">0</span></div>
-            <div>❤️ 체력: <span id="health">20</span>/<span id="maxHealth">20</span><span id="shield" class="shield-text"></span></div>
-            <div>🔋 마나: <span id="mana">10</span>/<span id="maxMana">10</span></div>
-            <div class="health-bar-container">
-                <div class="shield-bar" id="shield-bar"></div>
-                <div class="health-bar" id="hp-bar"></div>
-            </div>
-            <div class="mana-bar-container">
-                <div class="mana-bar" id="mp-bar"></div>
-            </div>
-            <div>🍗 배부름: <span id="fullness">0</span></div>
-            <div>❤️‍🩹 회복력: <span id="healthRegen">0</span></div>
-            <div>🔁 마나회복: <span id="manaRegen">0.5</span></div>
-            <div>⚔️ 공격력: <span id="attackStat">5</span> <span id="weaponBonus"></span><span id="attackBuff" class="attack-buff-text"></span></div>
-            <div>🛡️ 방어력: <span id="defense">1</span> <span id="armorBonus"></span></div>
-            <div>🎯 명중률: <span id="accuracy">0.8</span></div>
-            <div>💨 회피율: <span id="evasion">0.1</span></div>
-            <div>💥 치명타: <span id="critChance">0.05</span></div>
-            <div>🔮 마법공격: <span id="magicPower">0</span></div>
-            <div>✨ 마법방어: <span id="magicResist">0</span></div>
-            <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
-            <div><img src="assets/images/gold.png" class="inline-icon"> 골드: <span id="gold">0</span></div>
-            <div>🏰 층: <span id="floor">1</span></div>
-            <div id="equipped-tile-side">타일: 없음</div>
-            <div id="turn-effects"></div>
-        </div>
 
         <div id="inventory-panel" class="modal-panel wide">
             <button class="close-btn">X</button>
@@ -132,7 +134,6 @@
 
     <div id="game-over-panel" style="display:none;"></div>
     <div id="item-detail-panel" class="details-panel" style="display:none;"></div>
-    <div id="message-log"></div>
 
     <script src="dice.js"></script>
     <script type="module" src="./src/state.js"></script>

--- a/main.js
+++ b/main.js
@@ -24,8 +24,9 @@ const closeButtons = document.querySelectorAll('.close-btn');
 
 // --- [추가] 캔버스 크기 조절 함수 ---
 function resizeCanvas() {
-    const displayWidth = window.innerWidth;
-    const displayHeight = window.innerHeight;
+    const container = document.getElementById('game-container');
+    const displayWidth = container.clientWidth;
+    const displayHeight = container.clientHeight;
     const dpr = window.devicePixelRatio || 1;
 
     // CSS 크기를 먼저 설정해 비율을 고정합니다.

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7418,6 +7418,24 @@ function processTurn() {
 
             const playerDistance = getDistance(mercenary.x, mercenary.y, gameState.player.x, gameState.player.y);
 
+            if (mercenary.role === 'support') {
+                const purifyInfo = MERCENARY_SKILLS[mercenary.skill2];
+                if (purifyInfo && mercenary.skill2 === 'Purify' && !(mercenary.skillCooldowns[mercenary.skill2] > 0) &&
+                    mercenary.mana >= getSkillManaCost(mercenary, purifyInfo)) {
+                    const targets = [gameState.player, ...gameState.activeMercenaries.filter(m => m.alive)];
+                    const hasStatus = t => t.poison || t.burn || t.freeze || t.bleed || t.paralysis || t.nightmare || t.silence || t.petrify || t.debuff;
+                    const range = getSkillRange(mercenary, purifyInfo);
+                    const target = targets.find(t => hasStatus(t) && getDistance(mercenary.x, mercenary.y, t.x, t.y) <= range);
+                    if (target && purifyTarget(mercenary, target, purifyInfo)) {
+                        mercenary.mana -= getSkillManaCost(mercenary, purifyInfo);
+                        mercenary.skillCooldowns[mercenary.skill2] = getSkillCooldown(mercenary, purifyInfo);
+                        updateMercenaryDisplay();
+                        mercenary.hasActed = true;
+                        return;
+                    }
+                }
+            }
+
             // [최적화] 주변에 적이 있을 때만 전투 AI를 실행합니다.
             if (visibleMonsters.length > 0) {
                 const skillInfo = MERCENARY_SKILLS[mercenary.skill] || MONSTER_SKILLS[mercenary.skill];

--- a/style.css
+++ b/style.css
@@ -12,13 +12,43 @@ body {
     background-color: #000;
 }
 
+#layout {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+#top-area {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
 #game-container {
-    position: fixed; /* 화면에 위치를 고정합니다. */
-    top: 0;
-    left: 0;
-    width: 100vw; /* 보이는 화면의 너비 100% */
-    height: 100vh; /* 보이는 화면의 높이 100% */
+    flex: 1;
+    position: relative;
     z-index: 1; /* 다른 UI 요소들보다 뒤에 있도록 설정 */
+}
+
+#stats-panel.side-panel {
+    width: 300px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.side-panel {
+    background-image: var(--panel-bg);
+    background-color: #3a2d1d;
+    background-size: cover;
+    color: #111;
+    font-weight: bold;
+    padding: 20px;
+    border: 20px solid transparent;
+    border-image-source: var(--border-img);
+    border-image-slice: var(--border-slice);
+    border-image-repeat: repeat;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.8);
+    overflow-y: auto;
 }
 
 #game-canvas {
@@ -71,17 +101,13 @@ body {
 }
 
 #message-log {
-    position: fixed;
-    left: 10px;
-    bottom: 10px;
-    width: 300px;
-    max-height: 40vh;
+    width: 100%;
+    height: 25vh;
     overflow-y: auto;
     background-color: rgba(0, 0, 0, 0.7);
     color: #eee;
     font-size: 14px;
     padding: 5px;
-    z-index: 150;
 }
 
 #modal-overlay.hidden {
@@ -138,33 +164,3 @@ body {
     vertical-align: middle;
 }
 
-/* ================================== */
-/* Canvas 전체 화면 및 레이아웃 (필수) */
-/* ================================== */
-
-#game-container {
-    position: fixed; /* 화면에 위치를 고정합니다. */
-    top: 0;
-    left: 0;
-    width: 100vw;    /* 보이는 화면의 너비 100% */
-    height: 100vh;   /* 보이는 화면의 높이 100% */
-    z-index: 1;      /* 다른 UI 요소들보다 뒤에 있도록 설정 */
-}
-
-#game-canvas {
-    width: 100%;
-    height: 100%;
-    /* 해상도가 뭉개지지 않도록 선명하게 설정 */
-    image-rendering: pixelated; 
-    image-rendering: -moz-crisp-edges;
-    image-rendering: crisp-edges;
-}
-
-/* 상단 메뉴와 모달창이 게임 화면 위에 오도록 z-index를 높게 설정 */
-#top-menu-bar {
-    z-index: 100;
-}
-
-#modal-overlay {
-    z-index: 200;
-}


### PR DESCRIPTION
## Summary
- show stats panel permanently in top-right sidebar
- move message log below game board
- update canvas sizing logic for new layout
- let healers purify allies even when no enemies around

## Testing
- `npm test` *(fails: healerPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684e3e9cc5ac8327ac7b1e0ab3bee2ae