### PR TITLE
Fix camera edge movement

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -72,6 +72,12 @@ export function renderGame(canvas, ctx, images, gameState) {
     cameraX = Math.floor(cameraX);
     cameraY = Math.floor(cameraY);
 
+    // Store camera info so other modules can reference the current viewport
+    gameState.camera.x = cameraX;
+    gameState.camera.y = cameraY;
+    gameState.camera.width = Math.ceil(canvas.width / TILE_SIZE);
+    gameState.camera.height = Math.ceil(canvas.height / TILE_SIZE);
+
     const startCol = Math.max(0, cameraX);
     const endCol = Math.min(gameState.dungeonSize, cameraX + Math.ceil(canvas.width / TILE_SIZE) + 1);
     const startRow = Math.max(0, cameraY);

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6369,6 +6369,17 @@ function killMonster(monster, killer = null) {
             
             const newX = gameState.player.x + dx;
             const newY = gameState.player.y + dy;
+
+            // Prevent moving beyond the visible camera when the map is larger
+            if (typeof document !== 'undefined' && gameState.camera) {
+                const cam = gameState.camera;
+                const visW = cam.width || 0;
+                const visH = cam.height || 0;
+                const maxCamX = gameState.dungeonSize - visW;
+                const maxCamY = gameState.dungeonSize - visH;
+                if (visW && cam.x >= maxCamX && newX > cam.x + visW - 1) return;
+                if (visH && cam.y >= maxCamY && newY > cam.y + visH - 1) return;
+            }
             
             if (newX < 0 || newX >= gameState.dungeonSize || 
                 newY < 0 || newY >= gameState.dungeonSize) {


### PR DESCRIPTION
## Summary
- keep camera data in gameState
- block movement when player would leave the visible camera area

## Testing
- `npm test` *(fails: mercenaryFollow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684e4210ca048327ab78df93a85c56c6