### PR TITLE
Fix exports in mechanics

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -8666,7 +8666,7 @@ hasLineOfSight, healAction, healTarget, hideItemTargetPanel, hideItemDetailPanel
 hideMercenaryDetails, hideMonsterDetails, hideShop, hireMercenary, killMonster, killMercenary,
 loadGame, meleeAttackAction, monsterAttack, performMonsterSkill, movePlayer, nextFloor,
 processMercenaryTurn, processProjectiles, processTurn, purifyTarget, 
-rangedAction, recallMercenaries, recruitHatchedSuperior, handleHatchedMonsterClick,
+  rangedAction, recallMercenaries, pickUpAction, recruitHatchedSuperior, handleHatchedMonsterClick,
 removeEggFromIncubator, reviveMercenary, reviveMonsterCorpse,
  rollDice, saveGame, sellItem, confirmAndSell, enhanceItem, disassembleItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
 showChampionDetails, showItemDetailPanel, showItemTargetPanel, showMercenaryDetails,


### PR DESCRIPTION
## Summary
- include `pickUpAction` in `exportsObj`

## Testing
- `npm test` *(fails: mercenary did not move directly toward player when path blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ba88730832796831d7ce110cdec