### PR TITLE
Fix import error in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,13 +3,15 @@
 import { assetLoader, renderGame, updateTileSize } from './canvasRenderer.js';
 // ui.js와 mechanics.js의 경로가 src 폴더 안이라면 './src/ui.js' 와 같이 수정해주세요.
 import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay, showMonsterDetails, showMercenaryDetails } from './src/ui.js';
-import {
+import './src/mechanics.js';
+
+const {
     gameState, startGame, processTurn, movePlayer,
     skill1Action, skill2Action, meleeAttackAction, rangedAction, healAction,
     recallMercenaries, pickUpAction,
     findPath, autoMoveStep,
     saveGame, loadGame
-} from './src/mechanics.js';
+} = window;
 
 // --- UI 요소 가져오기 ---
 const canvas = document.getElementById('game-canvas');


### PR DESCRIPTION
## Summary
- import mechanics.js for side effects instead of named exports
- read needed functions from `window`

## Testing
- `npm test` *(fails: `mercenaryFollow.test.js`, `magicProjectile.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684e7d3c0330832792b6905691f686ee