### PR TITLE
Fix missing detail exports

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@
 
 import { assetLoader, renderGame, updateTileSize } from './canvasRenderer.js';
 // ui.js와 mechanics.js의 경로가 src 폴더 안이라면 './src/ui.js' 와 같이 수정해주세요.
-import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay, showMonsterDetails, showMercenaryDetails } from './src/ui.js';
+import { updateStats, updateInventoryDisplay, updateMercenaryDisplay, updateSkillDisplay, updateMaterialsDisplay } from './src/ui.js';
 import './src/mechanics.js';
 
 const {
@@ -10,7 +10,8 @@ const {
     skill1Action, skill2Action, meleeAttackAction, rangedAction, healAction,
     recallMercenaries, pickUpAction,
     findPath, autoMoveStep,
-    saveGame, loadGame
+    saveGame, loadGame,
+    showMonsterDetails, showMercenaryDetails
 } = window;
 
 // --- UI 요소 가져오기 ---


### PR DESCRIPTION
## Summary
- stop importing `showMonsterDetails` and `showMercenaryDetails` from `ui.js`
- read those functions directly from the global object

## Testing
- `npm test` *(fails: `mana on kill not applied`)*

------
https://chatgpt.com/codex/tasks/task_e_684e7f3e856883278d59706532c76df5