### PR TITLE
Fix tile sizing for map

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -4,10 +4,9 @@
 export let TILE_SIZE = 128;
 
 // 화면 크기에 맞춰 타일 크기를 동적으로 조절합니다.
-export function updateTileSize(displayWidth, displayHeight) {
-    const base = Math.min(displayWidth, displayHeight);
-    // 너무 크거나 작지 않도록 범위를 제한합니다.
-    TILE_SIZE = Math.max(32, Math.min(96, Math.floor(base / 20)));
+export function updateTileSize() {
+    // 이제 화면 크기와 무관하게 고정된 타일 크기를 사용합니다.
+    TILE_SIZE = 128;
 }
 
 // 이미지 로딩을 위한 객체

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 // main.js
 
-import { assetLoader, renderGame, updateTileSize } from './canvasRenderer.js';
+import { assetLoader, renderGame, updateTileSize, TILE_SIZE } from './canvasRenderer.js';
 // 게임 로직과 UI 헬퍼를 초기화합니다.
 import './src/mechanics.js';
 import './src/ui.js';
@@ -44,7 +44,7 @@ function resizeCanvas() {
     ctx.imageSmoothingEnabled = false;
 
     // CSS가 캔버스를 화면에 맞게 확대/축소하므로, 타일 크기는 내부 해상도 기준으로 계산합니다.
-    updateTileSize(internalWidth, internalHeight);
+    updateTileSize();
 
     // 리사이즈 후 즉시 다시 그려서 빈 화면이 보이지 않게 합니다.
     if (window.isGameReady) {
@@ -172,7 +172,6 @@ window.onload = () => {
             const mouseX = (event.clientX - rect.left) * scaleX;
             const mouseY = (event.clientY - rect.top) * scaleY;
 
-            const TILE_SIZE = 32;
             const startX = Math.floor(gameState.player.x - (canvas.width / TILE_SIZE / 2));
             const startY = Math.floor(gameState.player.y - (canvas.height / TILE_SIZE / 2));
 


### PR DESCRIPTION
## Summary
- fix TILE_SIZE update to use fixed 128px tiles
- use TILE_SIZE from canvasRenderer in main.js

## Testing
- `npm test` *(fails: manaOnKillAffix.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e831775f88327945f81c342eb6771